### PR TITLE
Bug修复与独立密钥配置在私聊场景的实现

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -80,7 +80,7 @@ async function onload() {
     ipcMain.handle("LiteLoader.encrypt_chat.imgDecryptor", (_, imgPath, peerUid) => imgDecryptor(imgPath, peerUid))
     ipcMain.handle("LiteLoader.encrypt_chat.imgChecker", (_, imgPath) => imgChecker(imgPath))
     //进行下载文件的解密与保存。
-    ipcMain.on("LiteLoader.encrypt_chat.ecFileHandler", (_, fileBuffer, fileName) => ecFileHandler(fileBuffer, fileName))
+    ipcMain.on("LiteLoader.encrypt_chat.ecFileHandler", (_, fileBuffer, fileName, peerUid) => ecFileHandler(fileBuffer, fileName, peerUid))
     //打开对应目录的文件夹
     ipcMain.on("LiteLoader.encrypt_chat.openPath", (_, filePath) => shell.openPath(filePath))
 

--- a/src/preload.js
+++ b/src/preload.js
@@ -10,7 +10,7 @@ contextBridge.exposeInMainWorld("encrypt_chat", {
     decodeHex: (message) => ipcRenderer.invoke("LiteLoader.encrypt_chat.decodeHex", message),
     getWindowID: () => ipcRenderer.invoke("LiteLoader.encrypt_chat.getWindowID"),
     getMenuHTML: () => ipcRenderer.invoke("LiteLoader.encrypt_chat.getMenuHTML"),
-    ecFileHandler: (fileBuffer, fileName) => ipcRenderer.send("LiteLoader.encrypt_chat.ecFileHandler", fileBuffer, fileName),
+    ecFileHandler: (fileBuffer, fileName, peerUid) => ipcRenderer.send("LiteLoader.encrypt_chat.ecFileHandler", fileBuffer, fileName, peerUid),
     openPath: (filePath) => ipcRenderer.send("LiteLoader.encrypt_chat.openPath", filePath),
     isFileExist: (filePathArray) => ipcRenderer.invoke("LiteLoader.encrypt_chat.isFileExist", filePathArray),
     //设置相关，给renderer进程用

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,6 +1,6 @@
 import {addFuncBarIcon, addMenuItemEC, changeECStyle, ECactivator} from "./utils/chatUtils.js";
 import {SettingListeners} from "./utils/SettingListeners.js"
-import {messageRenderer, patchCss, rePatchCss} from "./utils/rendererUtils.js";
+import {messageRenderer, patchCss, rePatchCss, listenMediaListChange} from "./utils/rendererUtils.js";
 
 const ecAPI = window.encrypt_chat
 await onLoad();//注入
@@ -42,10 +42,23 @@ async function onLoad() {
 
 function onHashUpdate() {
     const hash = location.hash;
-    if (hash === '#/blank') return
+    if (hash === '#/blank') return;
 
-    if (!(hash.includes("#/main/message") || hash.includes("#/chat"))) return;//不符合条件直接返回
+    // 聊天页面
+    if (hash.includes("#/main/message") || hash.includes("#/chat")) {
+        handleMainPage();
+        return;
+    }
 
+    // 图片查看器
+    if (hash.includes("#/image-viewer")) {
+        handleImageViewer();
+        return;
+    }
+}
+
+// 针对聊天页面的处理
+function handleMainPage() {
     console.log('[EC渲染进程]执行onHashUpdate~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
 
     ecAPI.addEventListener('LiteLoader.encrypt_chat.rePatchCss', rePatchCss) //监听设置被修改后，从主进程发过来的重新修改css请求
@@ -65,13 +78,11 @@ function onHashUpdate() {
         console.log(e)
     }
 
-    render()
+    mainRender()
 }
 
-
-//
-//渲染函数
-async function render() {
+// 聊天渲染器
+async function mainRender() {
     try {
         while (true) {
             await sleep(100)//稍微调大点
@@ -86,6 +97,18 @@ async function render() {
         console.log(e)
     }
 }
+
+
+// 针对图片查看器的处理
+function handleImageViewer() {
+    // 图片查看器
+    console.log('[EC渲染进程]执行onHashUpdate~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~');
+
+    // 监听图片查看MediaList的变化，动态解密图片
+    listenMediaListChange();
+}
+
+
 
 export async function sleep(ms) {
     return new Promise(resolve => {

--- a/src/utils/fileUtils.js
+++ b/src/utils/fileUtils.js
@@ -55,11 +55,15 @@ function ecFileHandler(filearrayBuffer, fileName, peerUid) {
     if (!decryptedBufFile) {
         pluginLog('文件解密失败！')
         return false
-    }//解密失败就不需要继续了
-    fs.writeFile(config.downloadFilePath + `\\${fileName}`, decryptedBufFile, (err) => {
+    }// 解密失败就不需要继续了
+    const savePath = path.join(config.downloadFilePath, fileName);
+    // 判断是否存在文件夹，不存在则创建
+    if (!fs.existsSync(config.downloadFilePath)) {
+        fs.mkdirSync(config.downloadFilePath)
+    }
+    fs.writeFile(savePath, decryptedBufFile, (err) => {
         if (err) pluginLog(err)
     })
-
 }
 
 

--- a/src/utils/fileUtils.js
+++ b/src/utils/fileUtils.js
@@ -47,11 +47,11 @@ function getFileBuffer(filePath) {
     })
 }
 
-function ecFileHandler(filearrayBuffer, fileName) {
+function ecFileHandler(filearrayBuffer, fileName, peerUid) {
     const fileBuffer = Buffer.from(filearrayBuffer, 'binary')
     pluginLog('获取到的文件buffer为')
     console.log(fileBuffer)
-    const decryptedBufFile = decryptImg(fileBuffer.slice(68))//可以用同样的办法解密文件，因为都是二进制
+    const decryptedBufFile = decryptImg(fileBuffer.slice(68), peerUid)//可以用同样的办法解密文件，因为都是二进制
     if (!decryptedBufFile) {
         pluginLog('文件解密失败！')
         return false

--- a/src/utils/rendererUtils.js
+++ b/src/utils/rendererUtils.js
@@ -619,6 +619,68 @@ async function ecOpenURL(event) {
 window.ecOpenURL=ecOpenURL
 
 
+export function listenMediaListChange() {
+    const store = app.__vue_app__?.config?.globalProperties?.$store;
+    if (!store) return;
+  
+    // 标记是否正在进行更新，防止由内部更新触发 watcher 循环
+    let isUpdating = false;
+  
+    store.watch(
+        // 监听 mediaList（深度监听）
+        (state) => state.MediaViewer.mediaList,
+        async (newMediaList, oldMediaList) => {
+            if (isUpdating) return; // 如果正在更新，则不再处理
+            console.log('mediaList 发生变化:', newMediaList);
+            
+            // 为了避免直接修改原数组，复制一份新的数组
+            const updatedMediaList = JSON.parse(JSON.stringify(newMediaList));
+          
+            // 遍历新列表，处理需要解密的图片
+            for (const media of updatedMediaList) {
+                if (media.type !== 'image') continue;
+                if (media.imageDecrypted) continue; // 如果已解密，则跳过
+                
+                // 标记为已尝试解密，防止后续重复处理
+                media.imageDecrypted = true;
+                const imgPath = decodeURIComponent(media.originPath).substring(9)//获取原始路径
+                if (!await ecAPI.imgChecker(imgPath)) {
+                    console.log('[EC]图片校验未通过！渲染原图')
+                    continue //图片检测未通过
+                }
+                const peerUid = media.context?.peerUid;
+                try {
+                    const decryptedObj = await ecAPI.imgDecryptor(imgPath, peerUid);
+                    if (!decryptedObj) continue;
+                    // 更新媒体对象相关属性
+                    media.originPath = "appimg://" + encodeURI(decryptedObj.decryptedImgPath.replace("\\", "/"));
+                    if (media.context) {
+                        media.context.sourcePath = decryptedObj.decryptedImgPath;
+                    }
+                    media.size = { width: decryptedObj.width, height: decryptedObj.height };
+                } catch (error) {
+                    console.error("解密错误:", error);
+                }
+            }
+          
+            if (JSON.stringify(newMediaList) === JSON.stringify(updatedMediaList)) return; // 如果没有变化，则不再更新
+
+            // 使用防重入标志防止由此更新再次触发 watcher
+            isUpdating = true;
+            if (store._mutations && store._mutations["MediaViewer/updateMediaList"]) {
+                store.commit("MediaViewer/updateMediaList", updatedMediaList);
+            } else {
+                store.state.MediaViewer.mediaList = updatedMediaList;
+            }
+            isUpdating = false;
+        },
+        {
+          deep: false
+        }
+    );
+  }
+  
+
 // const fileObj={
 //     type:'ec-encrypted-file',
 //     fileName: fileName,

--- a/src/utils/rendererUtils.js
+++ b/src/utils/rendererUtils.js
@@ -3,7 +3,7 @@ import "../assests/minJS/axios.min.js"
 //添加css样式
 const ecAPI = window.encrypt_chat
 let currentConfig = await ecAPI.getConfig()
-const downloadFunc = (fileObj, msgContent) => () => downloadFile(fileObj, msgContent)
+const downloadFunc = (fileObj, msgContent, peerUid) => () => downloadFile(fileObj, msgContent, peerUid)
 
 //const curAioData = app.__vue_app__.config.globalProperties.$store.state.common_Aio.curAioData
 export function patchCss() {
@@ -252,7 +252,8 @@ export async function checkMsgElement(msgElement) {
 export async function messageRenderer(allChats) {//下面对每条消息进行判断
     if(!(await ecAPI.getConfig()).useEncrypt) return//说明未开启加密，不做处理。
 
-    const uin = app.__vue_app__?.config?.globalProperties?.$store?.state?.common_Aio?.curAioData?.header.uin//当天聊天的对应信息
+    const uid = app.__vue_app__?.config?.globalProperties?.$store?.state?.common_Aio?.curAioData?.header.uid // 当天聊天的对应信息
+
     for (const chatElement of allChats) {
         try {
             const msgContentContainer = chatElement.querySelector('.msg-content-container')
@@ -281,7 +282,7 @@ export async function messageRenderer(allChats) {//下面对每条消息进行�
                         hexString = await checkMsgElement(child)
                         if (hexString) {
                             //pluginLog('检测到加密回复消息')
-                            const decryptedMsg = await ecAPI.messageDecryptor(hexString, uin)
+                            const decryptedMsg = await ecAPI.messageDecryptor(hexString, uid)
                             if (!decryptedMsg) continue//解密后如果消息是空的，那就直接忽略，进入下次循环
                             //直接修改内容
                             child.innerText = decryptedMsg
@@ -296,7 +297,7 @@ export async function messageRenderer(allChats) {//下面对每条消息进行�
 
 
                     if (hexString) {
-                        const decryptedMsg = await ecAPI.messageDecryptor(hexString, uin)
+                        const decryptedMsg = await ecAPI.messageDecryptor(hexString, uid)
                         if (!decryptedMsg) continue//解密后如果消息是空的，那就直接忽略，进入下次循环
 
                         //这里开始判断是否是文件
@@ -304,7 +305,7 @@ export async function messageRenderer(allChats) {//下面对每条消息进行�
                             totalOriginalMsg = '[EC文件]'//注意这里是直接=，因为如果是文件只可能有一个Msg。
 
                             //建立个函数进行fileDiv处理
-                            await fileDivCreater(msgContent, JSON.parse(decryptedMsg))
+                            await fileDivCreater(msgContent, JSON.parse(decryptedMsg), uid)
 
                         } else {
                             totalOriginalMsg += normalText.innerText//获取原本的密文
@@ -369,7 +370,7 @@ export async function messageRenderer(allChats) {//下面对每条消息进行�
                     //下面进行图片解密
                     //console.log('[EC]图片校验通过！尝试进行解密')
                     //解密图片
-                    const decryptedObj = await ecAPI.imgDecryptor(imgPath, uin)
+                    const decryptedObj = await ecAPI.imgDecryptor(imgPath, uid)
 
                     if (decryptedObj.decryptedImgPath !== "")  //解密成功才继续
                     {
@@ -421,7 +422,7 @@ export async function messageRenderer(allChats) {//下面对每条消息进行�
  * @param {Element} msgContent
  * @param {Object} fileObj
  */
-async function fileDivCreater(msgContent, fileObj) {
+async function fileDivCreater(msgContent, fileObj, peerUid) {
     msgContent.innerHTML = `
 <div class="ec-file-card">
     <div class="ec-file-info">
@@ -454,7 +455,7 @@ async function fileDivCreater(msgContent, fileObj) {
         })
     } else {
         // 添加下载按钮的点击事件
-        const funcReference = downloadFunc(fileObj, msgContent)
+        const funcReference = downloadFunc(fileObj, msgContent, peerUid)
         fileObj.downloadFunc = funcReference
         msgContent.querySelector('.ec-download-button').addEventListener('click', funcReference)
     }
@@ -550,7 +551,7 @@ function formatFileSize(bytes) {
     return Math.round(bytes / Math.pow(1024, i)) + ' ' + sizes[i];
 }
 
-function downloadFile(fileObj, msgContent) {
+function downloadFile(fileObj, msgContent, peerUid) {
     const progressElement = msgContent.querySelector('.progress')
     const iconElement = msgContent.querySelector('.ec-file-icon') //下载的图标元素
     const downloadButton = msgContent.querySelector('.ec-download-button')
@@ -579,9 +580,7 @@ function downloadFile(fileObj, msgContent) {
         }).then(response => {
             //通过IPC发送到主进程
             progressElement.style.display = 'none'
-            console.log(response.data)
-            console.log(JSON.stringify(response, null, 4))
-            ecAPI.ecFileHandler(response.data, fileObj.fileName)
+            ecAPI.ecFileHandler(response.data, fileObj.fileName, peerUid)
             //下载完成，图标修改为下载完成状态
             iconElement.innerHTML = `<path d="M383-327 167.5-542.5 221-596l162 162 356-356 53.5 53.5L383-327ZM210-170v-70h540v70H210Z"/>`
             //下面的下载按钮要改成打开所在目录

--- a/src/utils/rendererUtils.js
+++ b/src/utils/rendererUtils.js
@@ -641,7 +641,8 @@ export function listenMediaListChange() {
                 const indexQueue = [currMediaIndex];
 
                 // 根据距离的远近，将需要解密的图片放在前面
-                for (let i = 1; i <= mediaLength / 2; i++) {
+                const maxDistance = Math.max(currMediaIndex, mediaLength - 1 - currMediaIndex);
+                for (let i = 1; i <= maxDistance; i++) {
                     const left = currMediaIndex - i;
                     const right = currMediaIndex + i;
                     if (left >= 0) indexQueue.push(left);


### PR DESCRIPTION
In This PR:
- feat: 实现独立密钥配置下，私聊消息的加解密（包括文本消息、图片预览、文件下载）
- fix: 修复在同一消息中重复发送同一图片时消息发送失败的bug
- fix: 修复用图片查看器预览图片时，只有被双击的图片可预览，按左右键切换其他图片时预览失败的bug
- fix: 修复当同一条消息中存在多个图片时，双击预览非第一个图片时预览失败的bug
- enhance: 保证当`decryptedFiles`文件夹不存在时，尝试创建文件夹，以保证文件下载和保存

#### 目前仍然存在的bug
假设存在聊天窗口A（配置密钥1）、聊天窗口B（配置密钥2），将聊天窗口A设置为“独立的聊天窗口”，然后在主窗口的消息列表中点击聊天窗口B，使得主窗口的消息列表切换到与B的聊天状态，然后回到聊天窗口A，复制/拖动加密的图片，会解密失败。

原因是目前采用一个全局变量`currentUid`来暂存当前聊天对象的`uid`（用于判断加载哪个密钥），在监听到`nodeIKernelMsgService/setCurOnScreenMsgForMsgEvent`事件时进行更新，这在大多数情况下都是可行的，但是在对已被独立的聊天窗口获取焦点时，该事件不会被触发，导致`currentUid`没有能够及时更新。

虽然该bug触发场景比较少见，不过可能还是需要在未来寻求一个更好的解决方案。